### PR TITLE
Add support for location_lat and location_lon attributes

### DIFF
--- a/timetree_sdk/models/events.py
+++ b/timetree_sdk/models/events.py
@@ -20,7 +20,7 @@ class EventData(Base):
 
 
 class EventAttributes(Base):
-    def __init__(self, title=None, category=None, all_day=None, start_at=None, start_timezone=None, end_at=None, end_timezone=None, description=None, location=None, url=None, relationships=None):
+    def __init__(self, title=None, category=None, all_day=None, start_at=None, start_timezone=None, end_at=None, end_timezone=None, description=None, location=None, location_lat=None, location_lon=None, url=None, relationships=None):
 
         super(EventAttributes, self).__init__()
 
@@ -33,6 +33,8 @@ class EventAttributes(Base):
         self.end_timezone = end_timezone
         self.description = description
         self.location = location
+        self.location_lat = location_lat
+        self.location_lon = location_lon
         self.url = url
         self.label = self.get_or_new_from_json_dict(relationships, EventRelationships)
 


### PR DESCRIPTION
In order to resolve #4 two attributes (location_lat and location_lon) need to be added to the SDK to make it compatible with the responses from timetree.